### PR TITLE
Issue5 Test config

### DIFF
--- a/lib/quicksilver-config-client.js
+++ b/lib/quicksilver-config-client.js
@@ -26,10 +26,10 @@ class QuicksilverConfigClient {
     // Parse options.
     this.qsConfigPath = opts.qsConfigPath;
 
-    if (!this.configFileFound()) {
-      throw new TypeError('Configuration setting qsConfigPath does not resolve to ' +
-        'valid JSON file.');
-    }
+    this.configFileFound()
+      .then(function(response) {
+        return response;
+      });
 
     // Defaults.
     this.VERSION = VERSION;

--- a/lib/quicksilver-config-client.js
+++ b/lib/quicksilver-config-client.js
@@ -3,7 +3,6 @@
 const fs = require('fs');
 const jsonfile = require('jsonfile');
 
-
 /**
  * QuicksilverConfigClient
  *
@@ -31,7 +30,6 @@ class QuicksilverConfigClient {
       .catch((error) => {
         throw new TypeError('Configuration file missing, error: %s', error);
       });
-
 
     // Defaults.
     this.VERSION = VERSION;

--- a/lib/quicksilver-config-client.js
+++ b/lib/quicksilver-config-client.js
@@ -26,12 +26,12 @@ class QuicksilverConfigClient {
     // Parse options.
     this.qsConfigPath = opts.qsConfigPath;
 
+    // Confirm config file is found
     this.configFileFound()
-      .then((fileFound) => {
-        if (!fileFound) {
-          throw new Error('Config file not found.');
-        }
+      .catch((error) => {
+        throw new TypeError('Configuration file missing, error: :error', error);
       });
+
 
     // Defaults.
     this.VERSION = VERSION;
@@ -67,11 +67,11 @@ class QuicksilverConfigClient {
    */
   configFileFound() {
     return new Promise((resolve) => {
-      fs.lstat(this.qsConfigPath, (err, response) => {
+      fs.lstat(this.qsConfigPath, (err, res) => {
         if (err) {
           throw new Error(err);
         }
-        if (!response.isFile()) {
+        if (!res.isFile()) {
           throw new Error(err);
         }
         resolve(true);

--- a/lib/quicksilver-config-client.js
+++ b/lib/quicksilver-config-client.js
@@ -67,11 +67,11 @@ class QuicksilverConfigClient {
    */
   configFileFound() {
     return new Promise((resolve) => {
-      fs.lstat(this.qsConfigPath, (err, res) => {
+      fs.lstat(this.qsConfigPath, (err, stats) => {
         if (err) {
           throw new Error(err);
         }
-        if (!res.isFile()) {
+        if (!stats.isFile()) {
           throw new Error(err);
         }
         resolve(true);

--- a/lib/quicksilver-config-client.js
+++ b/lib/quicksilver-config-client.js
@@ -26,6 +26,11 @@ class QuicksilverConfigClient {
     // Parse options.
     this.qsConfigPath = opts.qsConfigPath;
 
+    if (!this.configFileFound()) {
+      throw new TypeError('Configuration setting qsConfigPath does not resolve to ' +
+        'valid JSON file.');
+    }
+
     // Defaults.
     this.VERSION = VERSION;
   }
@@ -55,16 +60,16 @@ class QuicksilverConfigClient {
   }
 
   /**
-   * Check that configuration file define in .env as QS_CONFIG_PATH is accessable.
+   * Check that configuration path (qsConfigPath) value defined in .env as QS_CONFIG_PATH
+   * is a valid path.
    */
   configFileFound() {
     return new Promise((resolve) => {
-      fs.access(this.qsConfigPath, fs.F_OK, (err) => {
-        const fileFound = true;
+      fs.lstat(this.qsConfigPath, (err) => {
         if (err) {
           throw new Error(err);
         }
-        resolve(fileFound);
+        resolve(true);
       });
     });
   }

--- a/lib/quicksilver-config-client.js
+++ b/lib/quicksilver-config-client.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const fs = require('fs');
+
 /**
  * QuicksilverConfigClient
  *
@@ -41,6 +43,19 @@ class QuicksilverConfigClient {
    */
   getSettingsByExchange() {
     return true;
+  }
+
+  /**
+   * Check that configuration file define in .env as QS_CONFIG_PATH is accessable.
+   */
+  configFileFound() {
+    fs.access(this.qsConfigPath, fs.F_OK, (err) => {
+      let status = false;
+      if (!err) {
+        status = true;
+      }
+      return status;
+    });
   }
 }
 

--- a/lib/quicksilver-config-client.js
+++ b/lib/quicksilver-config-client.js
@@ -27,8 +27,10 @@ class QuicksilverConfigClient {
     this.qsConfigPath = opts.qsConfigPath;
 
     this.configFileFound()
-      .then(function(response) {
-        return response;
+      .then((fileFound) => {
+        if (!fileFound) {
+          throw new Error('Config file not found.');
+        }
       });
 
     // Defaults.

--- a/lib/quicksilver-config-client.js
+++ b/lib/quicksilver-config-client.js
@@ -29,7 +29,7 @@ class QuicksilverConfigClient {
     // Confirm config file is found
     this.configFileFound()
       .catch((error) => {
-        throw new TypeError('Configuration file missing, error: :error', error);
+        throw new TypeError('Configuration file missing, error: %s', error);
       });
 
 
@@ -72,7 +72,7 @@ class QuicksilverConfigClient {
           throw new Error(err);
         }
         if (!stats.isFile()) {
-          throw new Error(err);
+          throw new Error('Configuration file not found at: %s', this.qsConfigPath);
         }
         resolve(true);
       });

--- a/lib/quicksilver-config-client.js
+++ b/lib/quicksilver-config-client.js
@@ -65,8 +65,11 @@ class QuicksilverConfigClient {
    */
   configFileFound() {
     return new Promise((resolve) => {
-      fs.lstat(this.qsConfigPath, (err) => {
+      fs.lstat(this.qsConfigPath, (err, response) => {
         if (err) {
+          throw new Error(err);
+        }
+        if (!response.isFile()) {
           throw new Error(err);
         }
         resolve(true);

--- a/test/quicksiler-config-client.test.js
+++ b/test/quicksiler-config-client.test.js
@@ -30,7 +30,7 @@ describe('QuicksilverConfigClient', () => {
     });
 
     // Check QS_CONFIG_PATH has a value.
-    it('QS_CONFIG_PATH in .env should be set', () => {
+    it('QS_CONFIG_PATH in process.env should be set', () => {
       process.env.QS_CONFIG_PATH.should.be.not.empty();
     });
 
@@ -42,7 +42,7 @@ describe('QuicksilverConfigClient', () => {
     });
 
     // Check QS_CONFIG_PATH has valid value by confirming access to the path to the JSON file.
-    it('QS_CONFIG_PATH in .env should point to valid JSON file', () => {
+    it('QS_CONFIG_PATH in process.env should point to valid JSON file', () => {
       const client = getConfigClient();
       const configFileFound = client.configFileFound();
       return configFileFound.should.eventually.equal(true);

--- a/test/quicksiler-config-client.test.js
+++ b/test/quicksiler-config-client.test.js
@@ -27,8 +27,8 @@ describe('QuicksilverConfigClient', () => {
       (() => new QuicksilverConfigClient()).should.throw(TypeError);
     });
 
-    // Check API base URL.
-    it('base URL option should be set', () => {
+    // Check QS_CONFIG_PATH has a value.
+    it('QS_CONFIG_PATH in .env should be set', () => {
       process.env.QS_CONFIG_PATH.should.be.not.empty();
     });
 
@@ -37,6 +37,13 @@ describe('QuicksilverConfigClient', () => {
       const client = getConfigClient();
       client.should.be.an.instanceof(QuicksilverConfigClient);
       client.should.have.property('qsConfigPath').which.is.not.empty();
+    });
+
+    // Check QS_CONFIG_PATH has valid value by confirming access to the path to the JSON file.
+    it('QS_CONFIG_PATH in .env should point to valid JSON file', () => {
+      const client = getConfigClient();
+      const configFileFound = client.configFileFound();
+      configFileFound.should.equal(true);
     });
   });
 });


### PR DESCRIPTION
Fixes #5

Test if valid configuration value `QS_CONFIG_PATH` in .env points to a file that exists and can be read.

**To Test**:
- `npm test` will run the new "'QS_CONFIG_PATH in .env should point to valid JSON file'" test 
- `client.configFileFound()` should return true

```
 ․․․․
  4 passing (13ms)
```
